### PR TITLE
Working initial Module CRD for dGPU prototype

### DIFF
--- a/ooto_v1alpha1_module.yaml
+++ b/ooto_v1alpha1_module.yaml
@@ -14,20 +14,26 @@ spec:
       capabilities:
         add: [SYS_MODULE]
   kernelMappings:
-    - regexp: '^.*\.x86_64$'
-      containerImage: image-registry.openshift-image-registry.svc:5000/intel-dgpu-kmod/intel-dgpu-driver-container:demo
+    - literal: 4.18.0-305.45.1.el8_4.x86_64
+      containerImage:  default-route-openshift-image-registry.apps.orjfdciocp.otcdcslab.com/intel-dgpu/intel-dgpu-driver-container:4.18.0-305.45.1.el8_4.x86_64
+      #containerImage: quay.io/ocpeng/intel-dgpu-driver-container:4.18.0-305.45.1.el8_4.x86_64
+      #- regexp: '^.*\.x86_64$'
+      #containerImage: image-registry.openshift-image-registry.svc:5000/intel-dgpu-kmod/intel-dgpu-driver-container:demo
       build:
         buildArgs:
           - name: SOME_KEY
             value: SOME_VALUE
         pull:
-          insecure: false
+          insecure: true
+          secret:
+            name: default-dockercfg-s97jv
         push:
-          insecure: false
+          insecure: true
+          secret:
+            name: kmmo-demo # Service Acccount permission workaround for OCP, manually adding build secret to default SA
         dockerfile: |
-          FROM
-          quay.io/openshift-release-dev/ocp-v4.0-art-dev
-          as builder
+          FROM image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit@sha256:57d069fbf5c4ea61bd260e6ea8f94e5f6e7e732a0129ba63bf1642ac910da73a as builder
+          # use KERNEL_VERSION above, hardcode for now
 
 
           WORKDIR /build/
@@ -39,47 +45,35 @@ spec:
           # install bison
 
           ARG BISON_VERSION=3.8
+          #RUN echo $BISON_VERSION
 
-          ADD http://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz /bison/
+          ADD http://ftp.gnu.org/gnu/bison/bison-3.8.tar.gz /bison/
 
-          RUN tar -xzvf /bison/bison-${BISON_VERSION}.tar.gz -C /bison/ && cd
-          /bison/bison-${BISON_VERSION} && ./configure && make && make install
+          RUN tar -xzvf /bison/bison-3.8.tar.gz -C /bison/ && cd /bison/bison-3.8 && ./configure && make && make install
 
 
           # install flex
 
           ARG FLEX_VERSION=2.6.4
 
-          ADD
-          https://github.com/westes/flex/files/981163/flex-${FLEX_VERSION}.tar.gz
-          /flex/
+          ADD https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz /flex/
 
-          RUN tar -xzvf /flex/flex-${FLEX_VERSION}.tar.gz -C /flex/ && cd
-          /flex/flex-${FLEX_VERSION} && ./configure && make && make install
+          RUN tar -xzvf /flex/flex-2.6.4.tar.gz -C /flex/ && cd /flex/flex-2.6.4 && ./configure && make && make install
 
 
           # build cse driver
 
-          RUN git clone -b rhel85
-          https://github.com/Walnux/intel-gpu-cse-backports.git && cd
-          intel-gpu-cse-backports && make && make modules_install
+          RUN git clone -b rhel85 https://github.com/Walnux/intel-gpu-cse-backports.git && cd intel-gpu-cse-backports && make && make modules_install
 
           # build pmt driver
 
-          RUN git clone -b rhel85
-          https://github.com/Walnux/intel-gpu-pmt-backports.git && cd
-          intel-gpu-pmt-backports && make && make modules_install
+          RUN git clone -b rhel85 https://github.com/Walnux/intel-gpu-pmt-backports.git && cd intel-gpu-pmt-backports && make && make modules_install
 
-          # both dmabuf and i915 build compat/i915-compat.ko since the compat
-          dir is not removed when building i915. it is a problem?
+          # both dmabuf and i915 build compat/i915-compat.ko since the compat dir is not removed when building i915. it is a problem?
 
           # build dmabuf driver
 
-          RUN git clone -b redhat/main
-          https://github.com/Walnux/intel-gpu-i915-backports.git && cd
-          intel-gpu-i915-backports && patch -p1 < scripts/disable_drm.patch &&
-          export LEX=flex; export YACC=bison && cp defconfigs/drm .config &&
-          make oldconfig && make -j $(nproc) && make modules_install
+          RUN git clone -b redhat/main https://github.com/Walnux/intel-gpu-i915-backports.git && cd intel-gpu-i915-backports && patch -p1 < scripts/disable_drm.patch && export LEX=flex; export YACC=bison && cp defconfigs/drm .config && make oldconfig && make -j $(nproc) && make modules_install
 
           # clean up dambuf building
 
@@ -88,10 +82,7 @@ spec:
 
           # build i915 driver
 
-          RUN cd intel-gpu-i915-backports && patch -p1 <
-          scripts/disable_dma.patch && export LEX=flex; export YACC=bison && cp
-          defconfigs/i915 .config &&  make oldconfig && make -j $(nproc) && make
-          modules_install
+          RUN cd intel-gpu-i915-backports && patch -p1 < scripts/disable_dma.patch && export LEX=flex; export YACC=bison && cp defconfigs/i915 .config &&  make oldconfig && make -j $(nproc) && make modules_install
 
           # clean up i915 building
 
@@ -109,11 +100,11 @@ spec:
 
           COPY --from=builder /etc/driver-toolkit-release.json /etc/
 
-          COPY --from=builder /lib/modules/4.18.0-305.45.1.el8_4.x86_64/*
-          /opt/lib/modules/4.18.0-305.45.1.el8_4.x86_64/
+          COPY --from=builder /lib/modules/4.18.0-305.45.1.el8_4.x86_64/* /opt/lib/modules/4.18.0-305.45.1.el8_4.x86_64/
 
-          COPY --from=builder /build/intel-gpu-firmware/firmware/*.bin
-          /opt/lib/firmware/updates/i915/
+          COPY --from=builder /build/intel-gpu-firmware/firmware/*.bin /opt/lib/firmware/updates/i915/
+
+          RUN depmod -b /opt
   selector:
           intel.feature.node.kubernetes.io/gpu: 'true'
           #feature.node.kubernetes.io/pci-0300_8086.present: "true"


### PR DESCRIPTION
Summary: This intel-dgpu module CRD successfully builds the driver container and creates daemon set to install driver container on selected node.
Changes:
*Using in cluster registry for DTK base image in dockerfile and containerImage location where driver container is built
*Added pull and push docker secret to use Kaniko build service and access redhat ubi8 minimal image from RH registry.
*Hardcoded Bison and Flex version as Kaniko does not support build argument variables. 

Signed-off-by: hershpa <hersh.pathak@intel.com>