### PR TITLE
Update module CRD.

### DIFF
--- a/ooto_v1alpha1_module.yaml
+++ b/ooto_v1alpha1_module.yaml
@@ -1,7 +1,16 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    app: intel-dgpu-driver-container-kmmo
+  name: intel-dgpu-driver-container-kmmo
+  namespace: intel-dgpu
+spec: {}
+---
 apiVersion: ooto.sigs.k8s.io/v1alpha1
 kind: Module
 metadata:
-  name: intel-dgpu
+  name: intel-dgpu-kmmo
   namespace: intel-dgpu
 spec:
         #devicePlugin:
@@ -10,23 +19,25 @@ spec:
   serviceAccountName: intel-dgpu-sa
   driverContainer:
     image:
-    name: intel-dgpu-driver-container
+    name: intel-dgpu-driver-container-kmmo
     securityContext:
+      seLinuxOptions:
+        type: spc_t
       capabilities:
         add: [SYS_MODULE]
+      #privileged: true
     command: [sleep, infinity]
     #lifecycle:
     #  postStart:
     #    exec:
-    #      command: [modprobe, -vd, /opt, intel-dgpu]
+    #      command: [modprobe, -vd, /opt, i915]
     #  preStop:
     #    exec:
-    #     command: [modprobe, -rvd, /opt, intel-dgpu]
+    #     command: [modprobe, -rvd, /opt, i915]
   kernelMappings:
     #- literal: 4.18.0-305.45.1.el8_4.x86_64
     - regexp: '^.*\.x86_64$'
-      #containerImage: quay.io/ocpeng/intel-dgpu-driver-container:$KERNEL_FULL_VERSION
-      containerImage: image-registry.openshift-image-registry.svc:5000/intel-dgpu/intel-dgpu-driver-container:$KERNEL_FULL_VERSION
+      containerImage: image-registry.openshift-image-registry.svc:5000/intel-dgpu/intel-dgpu-driver-container-kmmo:$KERNEL_FULL_VERSION
       build:
         buildArgs:
             - name: BISON_VERSION
@@ -35,49 +46,56 @@ spec:
               value: "2.6.4"
         pull:
           insecureSkipTLSVerify: true
-          insecure: true
+          insecure: false
           secret:
-            name: default-dockercfg-s97jv
+            name: default-dockercfg-wgt4l
         push:
           insecureSkipTLSVerify: true
-          insecure: true
+          insecure: false
           secret:
             name: kmmo-demo # Service Account permission workaround for OCP, manually adding build secret to default SA
+
         dockerfile: |
-          FROM image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit@sha256:57d069fbf5c4ea61bd260e6ea8f94e5f6e7e732a0129ba63bf1642ac910da73a as builder
-          # use KERNEL_VERSION above, hardcoded DTK base image for now
+          # DTK base image dynamically retrieved from in cluster registry
+          FROM image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit:latest
+
           WORKDIR /build/
-          RUN dnf install -y patch gcc m4 make tar && dnf clean all
+          RUN dnf install -y patch gcc m4 make tar kmod && dnf clean all
+
           # install bison
           ARG BISON_VERSION
-          RUN echo $BISON_VERSION
-          ADD http://ftp.gnu.org/gnu/bison/bison-3.8.tar.gz /bison/
-          RUN tar -xzvf /bison/bison-3.8.tar.gz -C /bison/ && cd /bison/bison-3.8 && ./configure && make && make install
+          ADD http://ftp.gnu.org/gnu/bison/bison-$BISON_VERSION.tar.gz /bison/
+          RUN tar -xzvf /bison/bison-$BISON_VERSION.tar.gz -C /bison/ && cd /bison/bison-$BISON_VERSION && ./configure && make && make install
+
           # install flex
           ARG FLEX_VERSION
-          RUN echo $FLEX_VERSION
-          ADD https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz /flex/
-          RUN tar -xzvf /flex/flex-2.6.4.tar.gz -C /flex/ && cd /flex/flex-2.6.4 && ./configure && make && make install
-          # build cse driver
-          RUN git clone -b rhel85 https://github.com/Walnux/intel-gpu-cse-backports.git && cd intel-gpu-cse-backports && make && make modules_install
-          # build pmt driver
-          RUN git clone -b rhel85 https://github.com/Walnux/intel-gpu-pmt-backports.git && cd intel-gpu-pmt-backports && make && make modules_install
-          # both dmabuf and i915 build compat/i915-compat.ko since the compat dir is not removed when building i915. it is a problem?
-          # build dmabuf driver
-          RUN git clone -b redhat/main https://github.com/Walnux/intel-gpu-i915-backports.git && cd intel-gpu-i915-backports && patch -p1 < scripts/disable_drm.patch && export LEX=flex; export YACC=bison && cp defconfigs/drm .config && make oldconfig && make -j $(nproc) && make modules_install
-          # clean up dambuf building
-          RUN cd intel-gpu-i915-backports && git reset --hard
-          # build i915 driver
-          RUN cd intel-gpu-i915-backports && patch -p1 < scripts/disable_dma.patch && export LEX=flex; export YACC=bison && cp defconfigs/i915 .config &&  make oldconfig && make -j $(nproc) && make modules_install
-          # clean up i915 building
-          RUN cd intel-gpu-i915-backports && git reset --hard
-          RUN git clone https://github.com/Walnux/intel-gpu-firmware.git
-          FROM registry.redhat.io/ubi8/ubi-minimal
-          RUN microdnf -y install kmod
-          COPY --from=builder /etc/driver-toolkit-release.json /etc/
-          COPY --from=builder /lib/modules/$KERNEL_FULL_VERSION/* /opt/lib/modules/$KERNEL_FULL_VERSION/
-          COPY --from=builder /build/intel-gpu-firmware/firmware/*.bin /opt/lib/firmware/updates/i915/
+          ADD https://github.com/westes/flex/files/981163/flex-$FLEX_VERSION.tar.gz /flex/
+          RUN tar -xzvf /flex/flex-$FLEX_VERSION.tar.gz -C /flex/ && cd /flex/flex-$FLEX_VERSION && ./configure && make && make install
+
+          # build cse driver, latest version, public release
+          RUN git clone -b rhel85 https://github.com/intel-gpu/intel-gpu-cse-backports.git && cd intel-gpu-cse-backports && make && make modules_install
+
+          # build pmt driver, latest version, public release
+          RUN git clone -b rhel85 https://github.com/intel-gpu/intel-gpu-pmt-backports.git && cd intel-gpu-pmt-backports && make && make modules_install
+
+          # build i915 driver,latest RHEL8.6 release
+          RUN git clone -b redhat/main https://user:ENTER_TOKEN@github.com/intel.../drivers.gpu.....git && cd drivers.gpu.kernel.backporting.releases && export LEX=flex; export YACC=bison && cp defconfigs/drm .config && make olddefconfig && make -j $(nproc) && make modules_install
+
+          # build firmware, latest version, public release
+          RUN git clone https://github.com/intel-gpu/intel-gpu-firmware.git
+
+          # create output /opt/lib directories
+          RUN mkdir -p /opt/lib/modules/$KERNEL_FULL_VERSION/updates/
+          RUN mkdir -p /opt/lib/firmware/updates/i915/
+
+          # copy ko files to output directories
+          RUN cp -r /lib/modules/$KERNEL_FULL_VERSION/updates/* /opt/lib/modules/$KERNEL_FULL_VERSION/updates/
+          RUN cp -r /build/intel-gpu-firmware/firmware/*.bin /opt/lib/firmware/updates/i915/
+
+          RUN cp -r /build/intel-gpu-pmt-backports/bin/* /opt/lib/modules/$KERNEL_FULL_VERSION/updates/
+          RUN cp -r /build/intel-gpu-cse-backports/bin/* /opt/lib/modules/$KERNEL_FULL_VERSION/updates/
+
           RUN depmod -b /opt
   selector:
-          intel.feature.node.kubernetes.io/gpu: 'true'
-          #feature.node.kubernetes.io/pci-0300_8086.present: "true"
+          kubernetes.io/hostname: "worker1-gobi"
+          #intel.feature.node.kubernetes.io/gpu: 'true'


### PR DESCRIPTION
* DTK base image dynamically retrieved from in cluster registry
* Using spc_t label instead of privileged container
* Integrated image stream definition into module crd yaml
* Dockerfile updates using latest driver releases
* Using build arguments to specify bison and flex version 
* Using $KERNEL_FULL_VERSION to specify kernel version dynamically

Signed-off-by: hershpa hersh.pathak@intel.com